### PR TITLE
Issue68 executors future dependency

### DIFF
--- a/futures.bs
+++ b/futures.bs
@@ -1010,8 +1010,18 @@ In the *Return Type* column.
 A type that satisfies the Future requirements for the value type R.
 
 **With:**
-A type that satisfies the ContinuableFutureFuture requirements for the value
+A type that satisfies the ContinuableFuture requirements for the value
 type R and for which `returnvalue.get_executor()` returns x.
+
+
+In the *Operational Semantics* column.
+
+**Replace:**
+in the associated shared state of the resulting Future.
+
+**With:**
+in the resulting ContinuableFuture.
+
 
 
 ThenExecutor requirements
@@ -1035,8 +1045,17 @@ In the *Return Type* column.
 A type that satisfies the Future requirements for the value type R.
 
 **With:**
-A type that satisfies the ContinuableFutureFuture requirements for the value
+A type that satisfies the ContinuableFuture requirements for the value
 type R and for which `returnvalue.get_executor()` returns x.
+
+
+In the *Operational Semantics* column.
+
+**Replace:**
+in the associated shared state of the resulting Future.
+
+**With:**
+in the resulting ContinuableFuture.
 
 
 BulkTwoWayExecutor requirements
@@ -1049,6 +1068,14 @@ A type that satisfies the Future requirements for the value type R.
 **With:**
 A type that satisfies the ContinuableFutureFuture requirements for the value
 type R and for which `returnvalue.get_executor()` returns x.
+
+In the *Operational Semantics* column.
+
+**Replace:**
+in the associated shared state of the resulting Future.
+
+**With:**
+in the resulting ContinuableFuture.
 
 
 BulkThenExecutor requirements
@@ -1074,6 +1101,16 @@ A type that satisfies the Future requirements for the value type R.
 **With:**
 A type that satisfies the ContinuableFutureFuture requirements for the value
 type R and for which `returnvalue.get_executor()` returns x.
+
+
+In the *Operational Semantics* column.
+
+**Replace:**
+in the associated shared state of the resulting Future.
+
+**With:**
+in the resulting ContinuableFuture.
+
 
 twoway_t customization points
 --------------------
@@ -1202,7 +1239,7 @@ template<class Function, class ResultFactory, class SharedFactory>
 *Returns:* A future, whose shared state is made ready when the future returned
 by e.bulk_twoway_execute(f2, n, rf2, sf2) is made ready, containing the result
 in r1 (if decltype(rf1()) is non-void) or any exception thrown by an
-invocationf1. [Note: e.bulk_twoway_execute(f2) may return any future type that
+invocationf1. [Note: e.bulk_twoway_execute(f2) may greturn any future type that
 satisfies the Future requirements, and not necessarily std::experimental::future.
 One possible implementation approach is for the polymorphic wrapper to attach a
 continuation to the inner future via that object's then() member function. When

--- a/futures.bs
+++ b/futures.bs
@@ -1002,6 +1002,79 @@ Drop this entire section and replace with the `Future` requirements from this
 paper.
 
 
+TwoWayExecutor requirements
+--------------------
+In the *Return Type* column.
+
+**Replace:**
+A type that satisfies the Future requirements for the value type R.
+
+**With:**
+A type that satisfies the ContinuableFutureFuture requirements for the value
+type R and for which `returnvalue.get_executor()` returns x.
+
+
+ThenExecutor requirements
+--------------------
+In the type requirements list.
+
+**Replace:**
+ * fut denotes a future object satisfying the Future requirements,
+
+**With:**
+ * fut denotes a future object that:
+     * was returned by a call to `x.twoway_execute`, `x.bulk_twoway_execute`,
+       `x.then_execute`, or `x.bulk_then_execute` and meets the
+       `ContinuableFuture` requirements.
+     * was returned by a call to `execution::query(x, promise_contract_t<T>)` or
+       `execution::query(x, cancellable_promise_contract_t<T>)`
+
+In the *Return Type* column.
+
+**Replace:**
+A type that satisfies the Future requirements for the value type R.
+
+**With:**
+A type that satisfies the ContinuableFutureFuture requirements for the value
+type R and for which `returnvalue.get_executor()` returns x.
+
+
+BulkTwoWayExecutor requirements
+--------------------
+In the *Return Type* column.
+
+**Replace:**
+A type that satisfies the Future requirements for the value type R.
+
+**With:**
+A type that satisfies the ContinuableFutureFuture requirements for the value
+type R and for which `returnvalue.get_executor()` returns x.
+
+
+BulkThenExecutor requirements
+--------------------
+In the type requirements list.
+
+**Replace:**
+ * fut denotes a future object satisfying the Future requirements,
+
+**With:**
+ * fut denotes a future object that:
+     * was returned by a call to `x.twoway_execute`, `x.bulk_twoway_execute`,
+       `x.then_execute`, or `x.bulk_then_execute` and meets the
+       `ContinuableFuture` requirements.
+     * was returned by a call to `execution::query(x, promise_contract_t<T>)` or
+       `execution::query(x, cancellable_promise_contract_t<T>)`.
+
+In the *Return Type* column.
+
+**Replace:**
+A type that satisfies the Future requirements for the value type R.
+
+**With:**
+A type that satisfies the ContinuableFutureFuture requirements for the value
+type R and for which `returnvalue.get_executor()` returns x.
+
 twoway_t customization points
 --------------------
 **Replace:**
@@ -1181,5 +1254,5 @@ static_thread_pool executor types
       void bulk_twoway_execute(Function&& f, size_t n, ResultFactory&& rf, SharedFactory&& sf) const
 ```
 
-Replace the same instances in the documentation section below the main code 
+Replace the same instances in the documentation section below the main code
 block.

--- a/futures.bs
+++ b/futures.bs
@@ -1177,8 +1177,9 @@ ready. --end note]
 **With:**
 
 *Returns:* A value whose type satisfies the `ContinuableFuture` requirements.
-The returned future is made ready when `f1()` completes execution, with either
-the result of f1() or any exception thrown by f1().
+The returned future is made ready when `f1()` completes execution, with the
+result of `f1()` if `decltype(f1())` is non-void, void completion if
+`decltype(f1())` is void or any exception thrown by `f1()`.
 
 
 **Replace:**
@@ -1211,9 +1212,9 @@ shared and makes that shared state ready. --end note]
 **With:**
 
 *Returns:* A value whose type satisfies the `ContinuableFuture` requirements.
-The returned future is made ready when `f1()` completes execution, with either
-the result in `r1` (if `decltype(rf1())` is non-void) or any exception thrown by
-an invocation `f1`.
+The returned future is made ready when `f1()` completes execution, with
+the result in `r1` (if `decltype(rf1())` is non-void), valueless completion
+(if `decltype(rf1())` is void) or any exception thrown by an invocation `f1`.
 
 
 static_thread_pool executor types

--- a/futures.bs
+++ b/futures.bs
@@ -1069,3 +1069,75 @@ Class template executor
 [*Note:* We lose the executor information here. Potentially we should encode
  the future type, including its executor, in the properties of the polymorphic
  wrapper.]
+
+
+executor operations
+--------------------
+**Replace:**
+
+```
+template<class Function>
+  std::experimental::future<result_of_t<decay_t<Function>()>>
+    twoway_execute(Function&& f) const
+```
+
+**With:**
+
+```
+template<class Function>
+  /* implementation-defined future type */
+    twoway_execute(Function&& f) con
+```
+
+**Replace:**
+
+Returns: A future, whose shared state is made ready when the future returned by
+e.twoway_execute(f2) is made ready, containing the result of f1() or any
+exception thrown by f1(). [Note: e2.twoway_execute(f2) may return any future
+type that satisfies the Future requirements, and not necessarily
+std::experimental::future. One possible implementation approach is for the
+polymorphic wrapper to attach a continuation to the inner future via that
+object's then() member function. When invoked, this continuation stores the
+result in the outer future's associated shared and makes that shared state
+ready. --end note]
+
+**With:**
+
+*Returns:* A value whose type satisfies the `ContinuableFuture` requirements.
+The returned future is made ready when `f1()` completes execution, with either
+the result of f1() or any exception thrown by f1().
+
+
+**Replace:**
+
+template<class Function, class ResultFactory, class SharedFactory>
+  std::experimental::future<result_of_t<decay_t<ResultFactory>()>>
+    void bulk_twoway_execute(Function&& f, size_t n, ResultFactory&& rf, SharedFactory&& sf) const;
+
+
+**With:**
+```
+template<class Function, class ResultFactory, class SharedFactory>
+  /* implementation-defined future type */
+     bulk_twoway_execute(Function&& f, size_t n, ResultFactory&& rf, SharedFactory&& sf) const;
+```
+
+
+**Replace:**
+
+*Returns:* A future, whose shared state is made ready when the future returned
+by e.bulk_twoway_execute(f2, n, rf2, sf2) is made ready, containing the result
+in r1 (if decltype(rf1()) is non-void) or any exception thrown by an
+invocationf1. [Note: e.bulk_twoway_execute(f2) may return any future type that
+satisfies the Future requirements, and not necessarily std::experimental::future.
+One possible implementation approach is for the polymorphic wrapper to attach a
+continuation to the inner future via that object's then() member function. When
+invoked, this continuation stores the result in the outer future's associated
+shared and makes that shared state ready. --end note]
+
+**With:**
+
+*Returns:* A value whose type satisfies the `ContinuableFuture` requirements.
+The returned future is made ready when `f1()` completes execution, with either
+the result in `r1` (if `decltype(rf1())` is non-void) or any exception thrown by
+an invocation `f1`.

--- a/futures.bs
+++ b/futures.bs
@@ -1141,3 +1141,45 @@ shared and makes that shared state ready. --end note]
 The returned future is made ready when `f1()` completes execution, with either
 the result in `r1` (if `decltype(rf1())` is non-void) or any exception thrown by
 an invocation `f1`.
+
+
+static_thread_pool executor types
+--------------------
+**Replace:**
+```
+    template<class Function>
+      std::experimental::future<result_of_t<decay_t<Function>()>>
+        twoway_execute(Function&& f) const
+
+    template<class Function, class Future>
+      std::experimental::future<result_of_t<decay_t<Function>(decay_t<Future>)>>
+        then_execute(Function&& f, Future&& pred) const;
+
+    template<class Function, class SharedFactory>
+      void bulk_execute(Function&& f, size_t n, SharedFactory&& sf) const;
+
+    template<class Function, class ResultFactory, class SharedFactory>
+      std::experimental::future<result_of_t<decay_t<ResultFactory>()>>
+        void bulk_twoway_execute(Function&& f, size_t n, ResultFactory&& rf, SharedFactory&& sf) const;
+```
+
+**With:**
+```
+  template<class Function>
+    std::standard_continuable_future<result_of_t<decay_t<Function>()>, C>
+      twoway_execute(Function&& f) const
+
+  template<class Function, class Future>
+    std::standard_continuable_future<result_of_t<decay_t<Function>(decay_t<Future>)>, C>
+      then_execute(Function&& f, Future&& pred) const;
+
+  template<class Function, class SharedFactory>
+    void bulk_execute(Function&& f, size_t n, SharedFactory&& sf) const;
+
+  template<class Function, class ResultFactory, class SharedFactory>
+    std::standard_continuable_future<result_of_t<decay_t<ResultFactory>()>>, C>
+      void bulk_twoway_execute(Function&& f, size_t n, ResultFactory&& rf, SharedFactory&& sf) const
+```
+
+Replace the same instances in the documentation section below the main code 
+block.

--- a/futures.bs
+++ b/futures.bs
@@ -815,7 +815,7 @@ template<class Future>
 
  * *Throws:* If `f` becomes ready with an exception, that exception is rethrown.
 
-Proposed Changes to Executors
+Proposed Addition to Executors P0443
 =============================
 
 [p0443](https://wg21.link/P0443) defines a collection of executor types intended
@@ -985,3 +985,87 @@ When `e` is neither a `ThenExecutor` nor a `BulkThenExecutor` the result of the
 query is a `std::pair` where the first value is a `std::promise<T>` and the
 second is a `std::future<T>` such that the future was retrieved from the
 promise.
+
+
+Proposed Modifications to Executors P0443
+=============================
+[p0443](https://wg21.link/P0443) currently requires `std::experimental::future`
+due to the absence of a complete future type in the core standard.
+
+This paper provides the wider set of tasks and as a result, the current text in
+[p0443](https://wg21.link/P0443) should be modified as follows.
+
+
+Future requirements
+--------------------
+Drop this entire section and replace with the `Future` requirements from this
+paper.
+
+
+twoway_t customization points
+--------------------
+**Replace:**
+
+    it is `std::experimental::future<T>`
+
+**with:**
+
+    it is `std::standard_continuable_future<T, E1>` such that a call to
+   `get_executor()` returns a copy of `e1`
+
+
+single_t customization points
+--------------------
+**Replace:**
+
+    it is `std::experimental::future<T>`
+
+**with:**
+
+    it is `std::standard_continuable_future<T, E1>` such that a call to
+    `get_executor()` returns a copy of `e1`
+
+
+Properties to indicate if blocking and directionality may be adapted
+--------------------
+Remove `twoway_t` from the **Requirements** column of hte table.
+
+Remove note referring to `std::experimental::future`.
+
+[*Note:* `std::experimental::future` is not used and the replacemnt does not
+ have a blocking wait so this is no longer relevant.]
+
+
+Class template executor
+--------------------
+**Replace:**
+```
+  template<class Function>
+    std::experimental::future<result_of_t<decay_t<Function>()>>
+      twoway_execute(Function&& f) const
+```
+
+**With:**
+```
+  template<class Function>
+    std::standard_semi_future<result_of_t<decay_t<Function>()>>
+      twoway_execute(Function&& f) const
+```
+
+**Replace:**
+```
+  template<class Function, class ResultFactory, class SharedFactory>
+    std::experimental::future<result_of_t<decay_t<ResultFactory>()>>
+      bulk_twoway_execute(Function&& f, size_t n, ResultFactory&& rf, SharedFactory&& sf) const;
+```
+
+**With:**
+```
+  template<class Function, class ResultFactory, class SharedFactory>
+    std::standard_semi_future<result_of_t<decay_t<ResultFactory>()>>
+      bulk_twoway_execute(Function&& f, size_t n, ResultFactory&& rf, SharedFactory&& sf) const;
+```
+
+[*Note:* We lose the executor information here. Potentially we should encode
+ the future type, including its executor, in the properties of the polymorphic
+ wrapper.]


### PR DESCRIPTION
Issue #68 

Added text to describe changes to P0443 that depend on "Future requirements" or "std::experimental::future" and replace with text that depends on the contents of this futures paper.

This is a fairly large chunk of text but it is mainly "change this to this" blocks for completeness of wording.