### PR TITLE
Use a friend function to specify promise_contract_t default behavior.

### DIFF
--- a/futures.bs
+++ b/futures.bs
@@ -1282,7 +1282,7 @@ struct cancellable_promise_contract_t
 
   template<class Executor>
     friend std::pair<std::promise<T>, std::future<T>>
-      query(const Executor& ex, const cancellable_promise_contract_t& p);
+      query(const Executor& ex, const cancellable_promise_contract_t&);
 
   CancellationCallback cancellation_callback;
 };
@@ -1313,7 +1313,7 @@ future parameter to calls to `then_execute` or `bulk_then_execute`.
 ```
 template<class Executor>
   friend std::pair<std::promise<T>, std::future<T>>
-    query(const Executor& ex, const promise_contract_t&);
+    query(const Executor& ex, const cancellable_promise_contract_t&);
 ```
  * *Returns:* A `std::pair` where the first value is a `std::promise<T>` and the
   second is a `std::future<T>` such that the future was retrieved from the

--- a/futures.bs
+++ b/futures.bs
@@ -1228,6 +1228,10 @@ struct promise_contract_t
   template<class Executor>
   static constexpr decltype(auto) static_query_v
     = Executor::query(promise_contract_t());
+
+  template<class Executor>
+    friend std::pair<std::promise<T>, std::future<T>>
+      query(const Executor& ex, const promise_contract_t&);
 };
 ```
 
@@ -1245,10 +1249,18 @@ When `e` is a `ThenExecutor` or `BulkThenExecutor` the result of the query is a
 `std::pair` where first value is an instance of a type matching the `Promise`
 requirements and the second is a token type that `e` will interpret as a valid
 future parameter to calls to `then_execute` or `bulk_then_execute`.
-When `e` is neither a `ThenExecutor` nor a `BulkThenExecutor` the result of the
-query is a `std::pair` where the first value is a `std::promise<T>` and the
-second is a `std::future<T>` such that the future was retrieved from the
-promise.
+
+```
+template<class Executor>
+  friend std::pair<std::promise<T>, std::future<T>>
+    query(const Executor& ex, const promise_contract_t&);
+```
+ * *Returns:* A `std::pair` where the first value is a `std::promise<T>` and the
+  second is a `std::future<T>` such that the future was retrieved from the
+  promise.
+
+ * *Remarks:* This function shall not participate in overload resolution unless
+  `executor_future_t<Executor, T>` is `std::future<T>`.
 
 
 1.3.3.2 Cancellable promise contract
@@ -1267,6 +1279,10 @@ struct cancellable_promise_contract_t
   template<class Executor>
   static constexpr decltype(auto) static_query_v
     = Executor::query(promise_contract_t());
+
+  template<class Executor>
+    friend std::pair<std::promise<T>, std::future<T>>
+      query(const Executor& ex, const cancellable_promise_contract_t& p);
 
   CancellationCallback cancellation_callback;
 };
@@ -1293,10 +1309,18 @@ When `e` is a `ThenExecutor` or `BulkThenExecutor` the result of the query is a
 `std::pair` where first value is an instance of a type matching the `Promise`
 requirements and the second is a token type that `e` will interpret as a valid
 future parameter to calls to `then_execute` or `bulk_then_execute`.
-When `e` is neither a `ThenExecutor` nor a `BulkThenExecutor` the result of the
-query is a `std::pair` where the first value is a `std::promise<T>` and the
-second is a `std::future<T>` such that the future was retrieved from the
-promise.
+
+```
+template<class Executor>
+  friend std::pair<std::promise<T>, std::future<T>>
+    query(const Executor& ex, const promise_contract_t&);
+```
+ * *Returns:* A `std::pair` where the first value is a `std::promise<T>` and the
+  second is a `std::future<T>` such that the future was retrieved from the
+  promise.
+
+ * *Remarks:* This function shall not participate in overload resolution unless
+  `executor_future_t<Executor, T>` is `std::future<T>`.
 
 
 Proposed Modifications to Executors P0443


### PR DESCRIPTION
This change aims to formalise the "default" implementation for a promise_contract_t query. Using a friend function within the property itself is the approach adopted in the executors paper itself.