### PR TITLE
Future and promise type specifications

### DIFF
--- a/futures.bs
+++ b/futures.bs
@@ -509,8 +509,16 @@ class standard_promise {
 public:
     using promise_default_executor = implementation-defined;
 
-    standard_future<T, promise_default_executor> get_future();
+    standard_continuable_future<T, promise_default_executor>
+      get_continuable_future();
+
     standard_semi_future<T> get_semi_future();
+
+    template<class Value>
+    void set_value(Value&& val);
+
+    template<class Error = std::exception_ptr>
+    void set_exception(Error&& val);
 };
 ```
 
@@ -519,6 +527,43 @@ code. This executor is intended for use only locally. It may be optimised
 using thread-local storage and should not be constructible. It is not copyable
 and its lifetime is not guaranteed to outlive a single continuation chain
 starting with a promise.
+
+<br/>
+```
+standard_future<T, promise_default_executor> get_continuable_future();
+```
+
+* *Effects:* Obtained a `standard_continuable_future` that completes on the
+  promise's default executor when `this->set_value(v)` or
+  `this->set_exception(e)` is called.
+
+* *Postconditions:* Further calls to `get_continuable_future()` or
+  to `get_semi_future()` will throw.
+
+<br/>
+```
+template<class Value>
+void set_value(Value&& val);
+```
+ * *Requires:* The result of `std::decay_t<Value>` is `T`.
+
+ * *Effects:* Completes the associated future with value `val`.
+
+ * *Postconditions:* Further calls to `set_value` or `set_exception` may throw.
+
+<br/>
+```
+template<class Error = std::exception_ptr>
+void set_exception(Error&& ex);
+```
+
+ * *Requires:* The result of `std::decay_t<Error>` is `std::exception_ptr`.
+
+ * *Effects:* Completes the associated future with exception `ex`.
+
+ * *Postconditions:* Further calls to `set_value` or `set_exception` may throw.
+
+
 
 `std::standard_semi_future`
 ---------------------------
@@ -536,7 +581,11 @@ public:
     standard_semi_future& operator=(const standard_semi_future&) = delete;
     standard_semi_future& operator=(standard_semi_future&&) = default;
 
-    standard_semi_future(standard_continuable_future<T>&&);
+    template<class E>
+    explicit standard_semi_future(standard_continuable_future<T, E>&&);
+
+    template<class E>
+    explicit standard_semi_future(standard_shared_future<T, E>&&);
 
     template<class EI, class EO>
     // Where EI and EO are  one-way or two-way executors.
@@ -545,6 +594,90 @@ public:
     standard_continuable_future<T, EO> via(EI) &&;
 };
 ```
+
+<br/>
+```
+standard_continuable_future(standard_semi_future&& rhs);
+```
+
+ * *Effects:*  Move constructs a future object that refers to the shared state
+   that was originally referred to by rhs (if any).
+
+ * *Postconditions:*
+     * valid() returns the same value as rhs.valid() prior to the constructor
+       invocation.
+     * rhs.valid() == false.
+
+<br/>
+```
+standard_semi_future(const standard_semi_future& rhs);
+```
+
+ * *Effects:* Copy constructs a future object that refers to the shared state
+   that was originally referred to by rhs (if any).
+
+ * *Postconditions:* valid() returns the same value as rhs.valid() prior to the
+   constructor invocation. The validity of rhs does not change.
+
+<br/>
+```
+template<class E>
+standard_semi_future(standard_continuable_future<T, E>&& rhs);
+```
+
+* *Effects:* Move constructs a future object that refers to the shared state that
+ was originally referred to by rhs (if any).
+
+* *Postconditions:*
+   * valid() returns the same value as rhs.valid() prior to the constructor invocation.
+   * rhs.valid() == false.
+
+
+<br/>
+```
+template<class E>
+explicit standard_semi_future(standard_shared_future<T, E>&& rhs);
+
+template<class E>
+explicit standard_semi_future(const standard_shared_future<T, E>& rhs);
+```
+
+ * *Effects:* Move constructs a future object that refers to the shared state
+   that was originally referred to by rhs (if any).
+
+ * *Postconditions:*
+    * valid() returns the same value as rhs.valid() prior to the constructor
+      invocation.
+    * rhs.valid() == false.
+
+<br/>
+```
+standard_continuable_future<T, EI> via(EI ex) &&;
+```
+
+ * *Effects:* Returns a new future that will complete when this completes but
+  on which continuations will be enqueued to a new executor.
+
+ * *Returns:* A standard_continuable_future modified to carry executor ex of
+   type EI.
+
+ * *Requires:*
+   * `e` is a `ThenExecutor` where
+     `INVOKE(e, [](T){}, execution::query(e, promise_contract_t<T>).second)` or
+     `INVOKE(e, [](T&){}, execution::query(e, promise_contract_t<T>).second)`
+     is valid.
+   * `e` is a `OnewayExecutor` or is convertible to a OnewayExecutor.
+
+ * *Postconditions:* valid() == false.
+
+<br/>
+```
+bool valid() const noexcept;
+```
+
+ * *Returns:* Returns true if this is a valid future. False otherwise.
+
+
 
 `std::standard_continuable_future`
 ----------------------------------
@@ -562,6 +695,11 @@ public:
 
     standard_continuable_future& operator=(const standard_continuable_future&) = delete;
     standard_continuable_future& operator=(standard_continuable_future&&) = default;
+
+    template<class E>
+    explicit standard_continuable_future(standard_shared_future<T, E>&&);
+    template<class E>
+    explicit standard_continuable_future(const standard_shared_future<T, E>&);
 
     template<class ReturnFuture, class F>
     // Where ReturnFuture will satisfy the requirements of ContinuableFuture,
@@ -586,19 +724,155 @@ public:
 };
 ```
 
+<br/>
 ```
-bool standard_continuable_future<T, E>::valid() const noexcept;
+standard_continuable_future(standard_continuable_future&& rhs);
+```
+
+ * *Effects:*  Move constructs a future object that refers to the shared state
+   that was originally referred to by rhs (if any).
+
+ * *Postconditions:*
+     * valid() returns the same value as rhs.valid() prior to the constructor
+       invocation.
+     * rhs.valid() == false.
+
+<br/>
+```
+standard_continuable_future(const standard_continuable_future& rhs);
+```
+
+ * *Effects:* Copy constructs a future object that refers to the shared state
+   that was originally referred to by rhs (if any).
+
+ * *Postconditions:* valid() returns the same value as rhs.valid() prior to the
+   constructor invocation. The validity of rhs does not change.
+
+<br/>
+```
+template<class E>
+explicit standard_continuable_future(standard_shared_future<T, E>&& rhs);
+
+template<class E>
+explicit standard_continuable_future(const standard_shared_future<T, E>& rhs);
+```
+
+ * *Effects:* Move constructs a future object that refers to the shared state that
+  was originally referred to by rhs (if any).
+
+ * *Postconditions:*
+    * valid() returns the same value as rhs.valid() prior to the constructor
+      invocation.
+    * rhs.valid() == false.
+
+<br/>
+```
+template<class ReturnFuture, class F>
+ReturnFuture then(F&&) &&;
+```
+
+ * *Requires:*
+   F satisfies the requirements of FutureContinuation.
+
+ * *Returns:* A `ContinuableFuture` that is bound to the executor `e` and
+   that wraps the type returned by execution of either the value or exception
+   operations implemented in the continuation. The type of the returned
+   `ContinuableFuture` is defined by `Executor` `E`.
+
+ * *Effects:*
+     * For `NORMAL` defined as the expression `DECAY_COPY(std::forward<F>(g))(val)` if
+       `T` is non-void and `DECAY_COPY(std::forward<F>(g))()` if `T` is void.
+
+     * For `EXCEPTIONAL` defined as the expression
+       `DECAY_COPY(std::forward<F>(f))(exception_arg, ex)`,
+
+     * When `*this` becomes nonexceptionally ready, and if `NORMAL` is a
+       well-formed expression, creates an execution agent which invokes `NORMAL`
+       at most once, with the call to `DECAY_COPY` being evaluated in the thread
+      that called `.then`.
+
+     * Otherwise, when `*this` becomes exceptionally ready, if `EXCEPTIONAL` is a
+       well-formed expression, creates an execution agent which invokes
+       `EXCEPTIONAL` at most once, with the call to `DECAY_COPY` being evaluated
+       in the thread that called `.then`.
+
+     * If `NORMAL` and `EXCEPTIONAL` are both well-formed expressions,
+       `decltype(EXCEPTIONAL)` shall be convertible to `R`.
+
+     * If `NORMAL` is not a well-formed expression and `EXCEPTIONAL` is a
+       well-formed expression, `decltype(EXCEPTIONAL)` shall be convertible to
+       `decltype(val)`.
+
+     * If neither `NORMAL` nor `EXCEPTIONAL` are well-formed expressions, the
+       invocation of `.then` shall be ill-formed.
+
+     * May block pending completion of `NORMAL` or `EXCEPTIONAL`.
+
+     * The invocation of `.then` synchronizes with
+       (C++Std [intro.multithread]) the invocation of `f`.
+
+     * Stores the result of either the `NORMAL` or `EXCEPTIONAL` expression, or
+       any exception thrown by either, in the associated shared state of the
+       resulting `ContinuableFuture`. Otherwise, stores either `val` or `e` in
+       the associated shared state of the resulting `ContinuableFuture`.
+
+ * *Postconditions:* valid() == false.
+
+<br/>
+```
+standard_continuable_future<T, EI> via(EI ex) &&;
+```
+
+ * *Effects:* Returns a new future that will complete when this completes but
+  on which continuations will be enqueued to a new executor.
+
+ * *Returns:* A standard_continuable_future modified to carry executor ex of
+   type EI.
+
+ * *Requires:*
+   * `e` is a `ThenExecutor` where
+     `INVOKE(e, [](T){}, execution::query(e, promise_contract_t<T>).second)` or
+     `INVOKE(e, [](T&){}, execution::query(e, promise_contract_t<T>).second)`
+     is valid.
+   * `e` is a `OnewayExecutor` or is convertible to a OnewayExecutor.
+
+  * *Postconditions:* valid() == false.
+
+<br/>
+```
+E get_executor() const;
+```
+ * *Returns:* If is_valid() returns true returns the executor contained within the
+   future. Otherwise throws std::future_error.
+
+<br/>
+```
+standard_semi_future<T> semi() &&;
+```
+ * *Returns:*
+   Returns a standard_semi_future of the same value type as \*this and that
+   completes when this completes, but that erases the executor. is_valid() on the
+   returned standard_semi_future will return the same value as is_valid() on
+   \*this.
+
+<br/>
+```
+bool valid() const noexcept;
 ```
 
  * *Returns:* Returns true if this is a valid future. False otherwise.
 
+<br/>
 ```
-standard_shared_future<T, E> standard_continuable_future<T, E>::share() &&;
+standard_shared_future<T, E> share() &&;
 ```
 
  * *Returns:* standard_shared_future<R>(std::move(\*this)).
 
  * *Postconditions:* valid() == false.
+
+
+
 
 
 `std::standard_shared_future`
@@ -616,10 +890,11 @@ namespace std {
       standard_shared_future(const standard_shared_future&) = default;
       standard_shared_future(standard_shared_future&&) = default;
 
-      standard_continuable_future& operator=(const standard_continuable_future&) = default
-      standard_continuable_future& operator=(standard_continuable_future&&) = default;
+      standard_shared_future& operator=(const standard_shared_future&) = default
+      standard_shared_future& operator=(standard_shared_future&&) = default;
 
-      standard_shared_future(standard_continuable_future&&);
+      template<class E>
+      explicit standard_shared_future(standard_continuable_future<T, E>&&);
 
       template<class ReturnFuture, class F>
       ReturnFuture then(FutureContinuation&&);
@@ -659,7 +934,7 @@ standard_shared_future(const standard_shared_future& rhs);
 
 <br/>
 ```
-standard_shared_future(standard_continuable_future&& rhs);
+explicit standard_shared_future(standard_continuable_future&& rhs);
 ```
 
  * *Effects:* Move constructs a future object that refers to the shared state that


### PR DESCRIPTION
Issue #69 

Fleshed out:
 * standard_promise
 * standard_semi_future
 * standard_continuable_future

Made corrections to the standard_shared_future interface for consistency.