### PR TITLE
Allow `get_executor` to throw

### DIFF
--- a/futures.bs
+++ b/futures.bs
@@ -322,8 +322,6 @@ Descriptive Variable Definitions
   <td>`E`</td>
   <td>
     **Returns:** The executor that the future is bound to.
-
-    **Throws:** Nothing.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
We should allow `get_executor` to throw, as the future may be stored in a shared state that has to be accessed via a synchronization primitive.

E.g. Imagine I have a traditional shared state future, and I stick the executor in my shared state, which is protected by a mutex and condition variable. One of those primitives could throw random OS exceptions, depending on the platform.

The executor presumably needs to be stored in the shared state as the promise needs access to it as well. The possibility of stateful executors would keep you from just making copies of the executor, and giving one to the future and one to the promise.
