### PR TITLE
Fixes for future types for fallback promise future query.

### DIFF
--- a/futures.bs
+++ b/futures.bs
@@ -1492,14 +1492,14 @@ struct promise_contract_t
   static constexpr bool is_preferable = false;
 
   using polymorphic_query_result_type
-    = std::pair<std::promise<T>, std::future<T>>;
+    = std::pair<std::standard_promise<T>, std::standard_semi_future<T>>;
 
   template<class Executor>
   static constexpr decltype(auto) static_query_v
     = Executor::query(promise_contract_t());
 
   template<class Executor>
-    friend std::pair<std::promise<T>, std::future<T>>
+    friend polymorphic_query_result_type
       query(const Executor& ex, const promise_contract_t&);
 };
 ```
@@ -1521,15 +1521,16 @@ future parameter to calls to `then_execute` or `bulk_then_execute`.
 
 ```
 template<class Executor>
-  friend std::pair<std::promise<T>, std::future<T>>
+  friend std::pair<std::standard_promise<T>, std::standard_semi_future<T>>
     query(const Executor& ex, const promise_contract_t&);
 ```
- * *Returns:* A `std::pair` where the first value is a `std::promise<T>` and the
-  second is a `std::future<T>` such that the future was retrieved from the
-  promise.
+ * *Returns:* A `std::pair` where the first value is a
+     `std::standard_promise<T>` and the second is a
+     `std::standard_semi_future<T>` such that the future was
+     retrieved from the promise.
 
  * *Remarks:* This function shall not participate in overload resolution unless
-  `executor_future_t<Executor, T>` is `std::future<T>`.
+     `executor_future_t<Executor, T>` is `std::standard_semi_future<T>`.
 
 
 1.3.3.2 Cancellable promise contract
@@ -1543,14 +1544,14 @@ struct cancellable_promise_contract_t
   static constexpr bool is_preferable = false;
 
   using polymorphic_query_result_type
-    = std::pair<std::promise<T>, std::future<T>>;
+    = std::pair<std::standard_promise<T>, std::standard_semi_future<T>>;
 
   template<class Executor>
   static constexpr decltype(auto) static_query_v
     = Executor::query(promise_contract_t());
 
   template<class Executor>
-    friend std::pair<std::promise<T>, std::future<T>>
+    friend std::pair<std::standard_promise<T>, std::standard_semi_future<T>>
       query(const Executor& ex, const cancellable_promise_contract_t&);
 
   CancellationCallback cancellation_callback;
@@ -1581,15 +1582,15 @@ future parameter to calls to `then_execute` or `bulk_then_execute`.
 
 ```
 template<class Executor>
-  friend std::pair<std::promise<T>, std::future<T>>
+  friend std::pair<std::standard_promise<T>, std::standard_semi_future<T>>
     query(const Executor& ex, const cancellable_promise_contract_t&);
 ```
  * *Returns:* A `std::pair` where the first value is a `std::promise<T>` and the
-  second is a `std::future<T>` such that the future was retrieved from the
-  promise.
+  second is a `std::standard_semi_future<T>` such that the future was retrieved
+  from the promise.
 
  * *Remarks:* This function shall not participate in overload resolution unless
-  `executor_future_t<Executor, T>` is `std::future<T>`.
+  `executor_future_t<Executor, T>` is `std::standard_semi_future<T>`.
 
 
 Proposed Modifications to Executors P0443

--- a/futures.bs
+++ b/futures.bs
@@ -1586,11 +1586,11 @@ template<class Executor>
     query(const Executor& ex, const cancellable_promise_contract_t&);
 ```
  * *Returns:* A `std::pair` where the first value is a `std::promise<T>` and the
-  second is a `std::standard_semi_future<T>` such that the future was retrieved
-  from the promise.
+      second is a `std::standard_semi_future<T>` such that the future was retrieved
+      from the promise.
 
  * *Remarks:* This function shall not participate in overload resolution unless
-  `executor_future_t<Executor, T>` is `std::standard_semi_future<T>`.
+      `executor_future_t<Executor, T>` is `std::standard_semi_future<T>`.
 
 
 Proposed Modifications to Executors P0443


### PR DESCRIPTION
Issue #93 

Change from std::future/std::promise (leftover from when this was a separate paper) to std::standard_semi_future/std::standard_promise.